### PR TITLE
tests/bcachefs: Factor out *-base.sh

### DIFF
--- a/tests/bcachefs/gcov-base.sh
+++ b/tests/bcachefs/gcov-base.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
+
+require-gcov fs/bcachefs
+
+call_base_test gcov "$@"

--- a/tests/bcachefs/gcov-ec.ktest
+++ b/tests/bcachefs/gcov-ec.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-gcov fs/bcachefs
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ec.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/gcov-base.sh

--- a/tests/bcachefs/gcov-quota.ktest
+++ b/tests/bcachefs/gcov-quota.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-gcov fs/bcachefs
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/quota.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/gcov-base.sh

--- a/tests/bcachefs/gcov-replication.ktest
+++ b/tests/bcachefs/gcov-replication.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-gcov fs/bcachefs
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/replication.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/gcov-base.sh

--- a/tests/bcachefs/gcov-single_device.ktest
+++ b/tests/bcachefs/gcov-single_device.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-gcov fs/bcachefs
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/single_device.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/gcov-base.sh

--- a/tests/bcachefs/gcov-subvol.ktest
+++ b/tests/bcachefs/gcov-subvol.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-gcov fs/bcachefs
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/subvol.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/gcov-base.sh

--- a/tests/bcachefs/gcov-tier.ktest
+++ b/tests/bcachefs/gcov-tier.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-gcov fs/bcachefs
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/tier.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/gcov-base.sh

--- a/tests/bcachefs/gcov-units.ktest
+++ b/tests/bcachefs/gcov-units.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-gcov fs/bcachefs
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/units.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/gcov-base.sh

--- a/tests/bcachefs/gcov-xfstests-nocow.ktest
+++ b/tests/bcachefs/gcov-xfstests-nocow.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-gcov fs/bcachefs
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/xfstests-nocow.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/gcov-base.sh

--- a/tests/bcachefs/gcov-xfstests.ktest
+++ b/tests/bcachefs/gcov-xfstests.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-gcov fs/bcachefs
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/xfstests.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/gcov-base.sh

--- a/tests/bcachefs/lockdep-kasan-base.sh
+++ b/tests/bcachefs/lockdep-kasan-base.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
+
+config-timeout-multiplier 3
+
+require-kernel-config PROVE_LOCKING
+require-kernel-config LOCKDEP_BITS=20
+require-kernel-config LOCKDEP_CHAINS_BITS=20
+
+require-kernel-config DEBUG_ATOMIC_SLEEP
+require-kernel-config PREEMPT
+require-kernel-config DEBUG_PREEMPT
+
+require-kernel-config KASAN
+require-kernel-config KASAN_VMALLOC
+
+call_base_test lockdep-kasan "$@"

--- a/tests/bcachefs/lockdep-kasan-ec.ktest
+++ b/tests/bcachefs/lockdep-kasan-ec.ktest
@@ -1,15 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-config-timeout-multiplier 3
-
-require-kernel-config PROVE_LOCKING
-require-kernel-config LOCKDEP_BITS=20
-require-kernel-config LOCKDEP_CHAINS_BITS=20
-require-kernel-config DEBUG_ATOMIC_SLEEP
-require-kernel-config KASAN
-require-kernel-config PREEMPT
-require-kernel-config DEBUG_PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ec.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/lockdep-kasan-base.sh

--- a/tests/bcachefs/lockdep-kasan-quota.ktest
+++ b/tests/bcachefs/lockdep-kasan-quota.ktest
@@ -1,15 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-config-timeout-multiplier 3
-
-require-kernel-config PROVE_LOCKING
-require-kernel-config LOCKDEP_BITS=20
-require-kernel-config LOCKDEP_CHAINS_BITS=20
-require-kernel-config DEBUG_ATOMIC_SLEEP
-require-kernel-config KASAN
-require-kernel-config PREEMPT
-require-kernel-config DEBUG_PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/quota.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/lockdep-kasan-base.sh

--- a/tests/bcachefs/lockdep-kasan-replication.ktest
+++ b/tests/bcachefs/lockdep-kasan-replication.ktest
@@ -1,15 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-config-timeout-multiplier 3
-
-require-kernel-config PROVE_LOCKING
-require-kernel-config LOCKDEP_BITS=20
-require-kernel-config LOCKDEP_CHAINS_BITS=20
-require-kernel-config DEBUG_ATOMIC_SLEEP
-require-kernel-config KASAN
-require-kernel-config PREEMPT
-require-kernel-config DEBUG_PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/replication.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/lockdep-kasan-base.sh

--- a/tests/bcachefs/lockdep-kasan-single_device.ktest
+++ b/tests/bcachefs/lockdep-kasan-single_device.ktest
@@ -1,15 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-config-timeout-multiplier 3
-
-require-kernel-config PROVE_LOCKING
-require-kernel-config LOCKDEP_BITS=20
-require-kernel-config LOCKDEP_CHAINS_BITS=20
-require-kernel-config DEBUG_ATOMIC_SLEEP
-require-kernel-config KASAN
-require-kernel-config PREEMPT
-require-kernel-config DEBUG_PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/single_device.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/lockdep-kasan-base.sh

--- a/tests/bcachefs/lockdep-kasan-subvol.ktest
+++ b/tests/bcachefs/lockdep-kasan-subvol.ktest
@@ -1,15 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-config-timeout-multiplier 3
-
-require-kernel-config PROVE_LOCKING
-require-kernel-config LOCKDEP_BITS=20
-require-kernel-config LOCKDEP_CHAINS_BITS=20
-require-kernel-config DEBUG_ATOMIC_SLEEP
-require-kernel-config KASAN
-require-kernel-config PREEMPT
-require-kernel-config DEBUG_PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/subvol.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/lockdep-kasan-base.sh

--- a/tests/bcachefs/lockdep-kasan-tier.ktest
+++ b/tests/bcachefs/lockdep-kasan-tier.ktest
@@ -1,15 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-config-timeout-multiplier 3
-
-require-kernel-config PROVE_LOCKING
-require-kernel-config LOCKDEP_BITS=20
-require-kernel-config LOCKDEP_CHAINS_BITS=20
-require-kernel-config DEBUG_ATOMIC_SLEEP
-require-kernel-config KASAN
-require-kernel-config PREEMPT
-require-kernel-config DEBUG_PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/tier.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/lockdep-kasan-base.sh

--- a/tests/bcachefs/lockdep-kasan-units.ktest
+++ b/tests/bcachefs/lockdep-kasan-units.ktest
@@ -1,15 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-config-timeout-multiplier 3
-
-require-kernel-config PROVE_LOCKING
-require-kernel-config LOCKDEP_BITS=20
-require-kernel-config LOCKDEP_CHAINS_BITS=20
-require-kernel-config DEBUG_ATOMIC_SLEEP
-require-kernel-config KASAN
-require-kernel-config PREEMPT
-require-kernel-config DEBUG_PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/units.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/lockdep-kasan-base.sh

--- a/tests/bcachefs/lockdep-kasan-xfstests-nocow.ktest
+++ b/tests/bcachefs/lockdep-kasan-xfstests-nocow.ktest
@@ -1,15 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-config-timeout-multiplier 3
-
-require-kernel-config PROVE_LOCKING
-require-kernel-config LOCKDEP_BITS=20
-require-kernel-config LOCKDEP_CHAINS_BITS=20
-require-kernel-config DEBUG_ATOMIC_SLEEP
-require-kernel-config KASAN
-require-kernel-config PREEMPT
-require-kernel-config DEBUG_PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/xfstests-nocow.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/lockdep-kasan-base.sh

--- a/tests/bcachefs/lockdep-kasan-xfstests.ktest
+++ b/tests/bcachefs/lockdep-kasan-xfstests.ktest
@@ -1,15 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-config-timeout-multiplier 3
-
-require-kernel-config PROVE_LOCKING
-require-kernel-config LOCKDEP_BITS=20
-require-kernel-config LOCKDEP_CHAINS_BITS=20
-require-kernel-config DEBUG_ATOMIC_SLEEP
-require-kernel-config KASAN
-require-kernel-config PREEMPT
-require-kernel-config DEBUG_PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/xfstests.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/lockdep-kasan-base.sh

--- a/tests/bcachefs/nodebug-base.sh
+++ b/tests/bcachefs/nodebug-base.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
+
+require-kernel-config PREEMPT
+export NO_BCACHEFS_DEBUG=1
+
+call_base_test nodebug "$@"

--- a/tests/bcachefs/nodebug-ec.ktest
+++ b/tests/bcachefs/nodebug-ec.ktest
@@ -1,8 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-export NO_BCACHEFS_DEBUG=1
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ec.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/nodebug-base.sh

--- a/tests/bcachefs/nodebug-quota.ktest
+++ b/tests/bcachefs/nodebug-quota.ktest
@@ -1,8 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-export NO_BCACHEFS_DEBUG=1
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/quota.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/nodebug-base.sh

--- a/tests/bcachefs/nodebug-replication.ktest
+++ b/tests/bcachefs/nodebug-replication.ktest
@@ -1,8 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-export NO_BCACHEFS_DEBUG=1
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/replication.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/nodebug-base.sh

--- a/tests/bcachefs/nodebug-single_device.ktest
+++ b/tests/bcachefs/nodebug-single_device.ktest
@@ -1,8 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-export NO_BCACHEFS_DEBUG=1
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/single_device.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/nodebug-base.sh

--- a/tests/bcachefs/nodebug-subvol.ktest
+++ b/tests/bcachefs/nodebug-subvol.ktest
@@ -1,8 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-export NO_BCACHEFS_DEBUG=1
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/subvol.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/nodebug-base.sh

--- a/tests/bcachefs/nodebug-tier.ktest
+++ b/tests/bcachefs/nodebug-tier.ktest
@@ -1,8 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-export NO_BCACHEFS_DEBUG=1
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/tier.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/nodebug-base.sh

--- a/tests/bcachefs/nodebug-units.ktest
+++ b/tests/bcachefs/nodebug-units.ktest
@@ -1,8 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-export NO_BCACHEFS_DEBUG=1
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/units.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/nodebug-base.sh

--- a/tests/bcachefs/nodebug-xfstests-nocow.ktest
+++ b/tests/bcachefs/nodebug-xfstests-nocow.ktest
@@ -1,8 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-export NO_BCACHEFS_DEBUG=1
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/xfstests-nocow.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/nodebug-base.sh

--- a/tests/bcachefs/nodebug-xfstests.ktest
+++ b/tests/bcachefs/nodebug-xfstests.ktest
@@ -1,8 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-export NO_BCACHEFS_DEBUG=1
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/xfstests.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/nodebug-base.sh

--- a/tests/bcachefs/preempt-base.sh
+++ b/tests/bcachefs/preempt-base.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
+
+require-kernel-config PREEMPT
+
+call_base_test preempt "$@"

--- a/tests/bcachefs/preempt-ec.ktest
+++ b/tests/bcachefs/preempt-ec.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ec.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/preempt-base.sh

--- a/tests/bcachefs/preempt-quota.ktest
+++ b/tests/bcachefs/preempt-quota.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/quota.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/preempt-base.sh

--- a/tests/bcachefs/preempt-replication.ktest
+++ b/tests/bcachefs/preempt-replication.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/replication.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/preempt-base.sh

--- a/tests/bcachefs/preempt-single_device.ktest
+++ b/tests/bcachefs/preempt-single_device.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/single_device.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/preempt-base.sh

--- a/tests/bcachefs/preempt-subvol.ktest
+++ b/tests/bcachefs/preempt-subvol.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/subvol.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/preempt-base.sh

--- a/tests/bcachefs/preempt-tier.ktest
+++ b/tests/bcachefs/preempt-tier.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/tier.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/preempt-base.sh

--- a/tests/bcachefs/preempt-units.ktest
+++ b/tests/bcachefs/preempt-units.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/units.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/preempt-base.sh

--- a/tests/bcachefs/preempt-xfstests-nocow.ktest
+++ b/tests/bcachefs/preempt-xfstests-nocow.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/xfstests-nocow.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/preempt-base.sh

--- a/tests/bcachefs/preempt-xfstests.ktest
+++ b/tests/bcachefs/preempt-xfstests.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/xfstests.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/preempt-base.sh

--- a/tests/bcachefs/ubsan-base.sh
+++ b/tests/bcachefs/ubsan-base.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
+
+require-kernel-config UBSAN
+
+call_base_test ubsan "$@"

--- a/tests/bcachefs/ubsan-ec.ktest
+++ b/tests/bcachefs/ubsan-ec.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config UBSAN
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ec.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ubsan-base.sh

--- a/tests/bcachefs/ubsan-quota.ktest
+++ b/tests/bcachefs/ubsan-quota.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config UBSAN
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/quota.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ubsan-base.sh

--- a/tests/bcachefs/ubsan-replication.ktest
+++ b/tests/bcachefs/ubsan-replication.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config UBSAN
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/replication.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ubsan-base.sh

--- a/tests/bcachefs/ubsan-single_device.ktest
+++ b/tests/bcachefs/ubsan-single_device.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config UBSAN
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/single_device.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ubsan-base.sh

--- a/tests/bcachefs/ubsan-subvol.ktest
+++ b/tests/bcachefs/ubsan-subvol.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config UBSAN
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/subvol.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ubsan-base.sh

--- a/tests/bcachefs/ubsan-tier.ktest
+++ b/tests/bcachefs/ubsan-tier.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config UBSAN
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/tier.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ubsan-base.sh

--- a/tests/bcachefs/ubsan-units.ktest
+++ b/tests/bcachefs/ubsan-units.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config UBSAN
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/units.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ubsan-base.sh

--- a/tests/bcachefs/ubsan-xfstests-nocow.ktest
+++ b/tests/bcachefs/ubsan-xfstests-nocow.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config UBSAN
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/xfstests-nocow.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ubsan-base.sh

--- a/tests/bcachefs/ubsan-xfstests.ktest
+++ b/tests/bcachefs/ubsan-xfstests.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config UBSAN
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/xfstests.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ubsan-base.sh

--- a/tests/prelude.sh
+++ b/tests/prelude.sh
@@ -273,7 +273,7 @@ list_tests()
 
 main()
 {
-    if [[ $BASH_ARGC = 0 ]]; then
+    if [[ $# = 0 ]]; then
 	exit 0
     fi
 

--- a/tests/test-libs.sh
+++ b/tests/test-libs.sh
@@ -95,3 +95,12 @@ stress_timeout()
 {
     echo $((($ktest_priority + 3) * 600))
 }
+
+call_base_test()
+{
+    fname=$(basename ${BASH_SOURCE[2]})
+    fname=${fname#$1-}
+    shift
+
+    . $(dirname $(readlink -e ${BASH_SOURCE[2]}))/$fname
+}


### PR DESCRIPTION
Add a new helper, call_base_test to test-libs.sh; -base.sh uses this to apply settings and call the base test, eliminating a bunch of duplication.

Also enable CONFIG_KASAN_VMALLOC in kasan tests.